### PR TITLE
Fix exporting issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 const { ProjectTokenBuilder } = require('./token');
 const { Client } = require('./client');
 
-exports = {
-  Client,
-  ProjectTokenBuilder,
-};
+exports.Client = Client;
+exports.ProjectTokenBuilder = ProjectTokenBuilder;


### PR DESCRIPTION
From the [Node docs](https://nodejs.org/api/modules.html#modules_exports_shortcut):

> It allows a shortcut, so that module.exports.f = ... can be written more succinctly as exports.f = .... However, be aware that like any variable, if a new value is assigned to exports, it is no longer bound to module.exports:

```
module.exports.hello = true; // Exported from require of module
exports = { hello: false };  // Not exported, only available in the module
```

Once this makes it out I'll [deprecate](https://docs.npmjs.com/cli/deprecate) 1.0.0.